### PR TITLE
Share a single _canvas_depth_node

### DIFF
--- a/src/Extensions/Voxelorama/Tools/CanvasDepth.gd
+++ b/src/Extensions/Voxelorama/Tools/CanvasDepth.gd
@@ -3,6 +3,8 @@ extends Node2D
 var _voxelorama_root_node: Node
 onready var extensions_api = get_node("/root/ExtensionsApi")
 
+var users :int = 1
+
 
 func _ready() -> void:
 	if extensions_api:
@@ -32,3 +34,11 @@ func _draw() -> void:
 			draw_string(font, Vector2(x, y) * 20 + Vector2.DOWN * 16, depth_str)
 	image.unlock()
 	draw_set_transform(position, rotation, scale)
+
+
+func request_deletion():
+	users -= 1
+	print(users)
+	if users == 0: # no one is using this node
+		queue_free()
+	# Else there are still active tool using this node so DENIED

--- a/src/Extensions/Voxelorama/Tools/CanvasDepth.tscn
+++ b/src/Extensions/Voxelorama/Tools/CanvasDepth.tscn
@@ -2,5 +2,5 @@
 
 [ext_resource path="res://src/Extensions/Voxelorama/Tools/CanvasDepth.gd" type="Script" id=1]
 
-[node name="CanvasDepth" type="Node2D"]
+[node name="CanvasDepth" type="Node2D" groups=["CanvasDepth"]]
 script = ExtResource( 1 )

--- a/src/Extensions/Voxelorama/Tools/Depth.gd
+++ b/src/Extensions/Voxelorama/Tools/Depth.gd
@@ -21,6 +21,12 @@ func _ready() -> void:
 	load_config()
 	if extensions_api:
 		_canvas = extensions_api.get_canvas()
+		for child in _canvas.get_children():
+			if child.is_in_group("CanvasDepth"):
+				_canvas_depth_node = child
+				_canvas_depth_node.users += 1
+				# We will share single _canvas_depth_node
+				return
 		_canvas_depth_node = _canvas_depth.instance()
 		_canvas.add_child(_canvas_depth_node)
 
@@ -131,6 +137,6 @@ func _on_DepthHSlider_value_changed(value: float) -> void:
 
 func _exit_tree() -> void:
 	if _canvas:
-		_canvas_depth_node.queue_free()
+		_canvas_depth_node.request_deletion()
 		if is_moving:
 			draw_end(_canvas.current_pixel.floor())


### PR DESCRIPTION
This makes both Left/Right tools share a single _canvas_depth_node instead of two separate nodes to avoid sync issues